### PR TITLE
Change sdk back to main

### DIFF
--- a/.github/workflows/post-diffs-in-pr.yml
+++ b/.github/workflows/post-diffs-in-pr.yml
@@ -10,3 +10,5 @@ concurrency:
 jobs:
   post_diffs:
     uses: codecrafters-io/course-sdk/.github/workflows/post-diffs-in-pr.yml@main
+    with:
+      sdkRef: main

--- a/.github/workflows/post-diffs-in-pr.yml
+++ b/.github/workflows/post-diffs-in-pr.yml
@@ -9,6 +9,4 @@ concurrency:
 
 jobs:
   post_diffs:
-    uses: codecrafters-io/course-sdk/.github/workflows/post-diffs-in-pr.yml@nikandfor/post_diffs_fix3
-    with:
-      sdkRef: nikandfor/post_diffs_fix3
+    uses: codecrafters-io/course-sdk/.github/workflows/post-diffs-in-pr.yml@main


### PR DESCRIPTION
During #17 we changed the SDK in post-diffs-in-pr.yml to an develop version for testing purpose. However, we forgot to change it back before merging.