### PR TITLE
Pass args correctly by quoting $@ in your_grep.sh

### DIFF
--- a/compiled_starters/grep-starter-haskell/your_grep.sh
+++ b/compiled_starters/grep-starter-haskell/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/01-init/code/your_grep.sh
+++ b/solutions/haskell/01-init/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/02-match_digit/code/your_grep.sh
+++ b/solutions/haskell/02-match_digit/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/03-match_alphanumeric/code/your_grep.sh
+++ b/solutions/haskell/03-match_alphanumeric/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/04-positive_character_groups/code/your_grep.sh
+++ b/solutions/haskell/04-positive_character_groups/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/05-negative_character_groups/code/your_grep.sh
+++ b/solutions/haskell/05-negative_character_groups/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/06-combining_character_classes/code/app/Main.hs
+++ b/solutions/haskell/06-combining_character_classes/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/06-combining_character_classes/code/your_grep.sh
+++ b/solutions/haskell/06-combining_character_classes/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/06-combining_character_classes/diff/app/Main.hs.diff
+++ b/solutions/haskell/06-combining_character_classes/diff/app/Main.hs.diff
@@ -51,7 +51,7 @@
    args <- getArgs
 -  let pattern = args !! 1
 -  input_line <- getLine
-+  let pattern = parse $ unwords $ tail args
++  let pattern = parse $ args !! 1
 
 -  if head args /= "-E"
 +  if isNothing pattern

--- a/solutions/haskell/07-start_of_string_anchor/code/app/Main.hs
+++ b/solutions/haskell/07-start_of_string_anchor/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/07-start_of_string_anchor/code/your_grep.sh
+++ b/solutions/haskell/07-start_of_string_anchor/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/08-end_of_string_anchor/code/app/Main.hs
+++ b/solutions/haskell/08-end_of_string_anchor/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/08-end_of_string_anchor/code/your_grep.sh
+++ b/solutions/haskell/08-end_of_string_anchor/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/09-one_or_more_quantifier/code/app/Main.hs
+++ b/solutions/haskell/09-one_or_more_quantifier/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/09-one_or_more_quantifier/code/your_grep.sh
+++ b/solutions/haskell/09-one_or_more_quantifier/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/10-zero_or_one_quantifier/code/app/Main.hs
+++ b/solutions/haskell/10-zero_or_one_quantifier/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/10-zero_or_one_quantifier/code/your_grep.sh
+++ b/solutions/haskell/10-zero_or_one_quantifier/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/11-wildcard/code/app/Main.hs
+++ b/solutions/haskell/11-wildcard/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/11-wildcard/code/your_grep.sh
+++ b/solutions/haskell/11-wildcard/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/solutions/haskell/12-alternation/code/app/Main.hs
+++ b/solutions/haskell/12-alternation/code/app/Main.hs
@@ -22,7 +22,7 @@ grep pattern = do
 main :: IO ()
 main = do
   args <- getArgs
-  let pattern = parse $ unwords $ tail args
+  let pattern = parse $ args !! 1
 
   if isNothing pattern
     then do

--- a/solutions/haskell/12-alternation/code/your_grep.sh
+++ b/solutions/haskell/12-alternation/code/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"

--- a/starter_templates/haskell/your_grep.sh
+++ b/starter_templates/haskell/your_grep.sh
@@ -5,4 +5,4 @@
 # CodeCrafters uses this file to test your code. Don't make any changes here!
 #
 # DON'T EDIT THIS!
-exec stack run --silent -- $@
+exec stack run --silent -- "$@"


### PR DESCRIPTION
Fix for #24.

Running `docker compose run tester scripts/compile_and_test.sh courses/build-your-own-grep haskell` did not fix `your_grep.sh` in all stage solutions (IIRC only the first one).

I ran `ruby scripts/propagate_changes.rb courses/build-your-own-grep/` to fix all stages.

I'll look into removing the `unwords` trick from the solutions as well with another commit in this PR.