### PR TITLE
CC-834 changed -E to -P

### DIFF
--- a/course-definition.yml
+++ b/course-definition.yml
@@ -60,7 +60,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "apple" | ./your_grep.sh -E "a"
+      $ echo "apple" | ./your_grep.sh -P "a"
       ```
 
       The `-E` flag instructs `grep` to interprets patterns as extended regular expressions (with support
@@ -92,7 +92,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "apple123" | ./your_grep.sh -E "\d"
+      $ echo "apple123" | ./your_grep.sh -P "\d"
       ```
 
       You program must exit with 0 if a digit is found in the string, and 1 if not.
@@ -124,7 +124,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "alpha-num3ric" | ./your_grep.sh -E "\w"
+      $ echo "alpha-num3ric" | ./your_grep.sh -P "\w"
       ```
 
       You program must exit with 0 if an alphanumeric character is found in the string, and 1 if not.
@@ -155,7 +155,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "apple" | ./your_grep.sh -E "[abc]"
+      $ echo "apple" | ./your_grep.sh -P "[abc]"
       ```
 
       You program must exit with 0 if an any of the characters are found in the string, and 1 if not.
@@ -185,7 +185,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "apple" | ./your_grep.sh -E "[^abc]"
+      $ echo "apple" | ./your_grep.sh -P "[^abc]"
       ```
 
       You program must exit with 0 if the input contains characters that aren't part of the negative character group, and 1 if not.
@@ -225,7 +225,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "1 apple" | ./your_grep.sh -E "\d apple"
+      $ echo "1 apple" | ./your_grep.sh -P "\d apple"
       ```
 
       You program must exit with 0 if the pattern matches the input, and 1 if not.
@@ -258,7 +258,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "log" | ./your_grep.sh -E "^log"
+      $ echo "log" | ./your_grep.sh -P "^log"
       ```
 
       You program must exit with 0 if the input starts with the given pattern, and 1 if not.
@@ -288,7 +288,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "dog" | ./your_grep.sh -E "dog$"
+      $ echo "dog" | ./your_grep.sh -P "dog$"
       ```
 
       You program must exit with 0 if the input matches the given pattern, and 1 if not.
@@ -316,7 +316,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "caats" | ./your_grep.sh -E "ca+ts"
+      $ echo "caats" | ./your_grep.sh -P "ca+ts"
       ```
 
       You program must exit with 0 if the input matches the given pattern, and 1 if not.
@@ -342,7 +342,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "dogs" | ./your_grep.sh -E "dogs?"
+      $ echo "dogs" | ./your_grep.sh -P "dogs?"
       ```
 
       You program must exit with 0 if the input matches the given pattern, and 1 if not.
@@ -368,7 +368,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "dog" | ./your_grep.sh -E "d.g"
+      $ echo "dog" | ./your_grep.sh -P "d.g"
       ```
 
       You program must exit with 0 if the input matches the given pattern, and 1 if not.
@@ -394,7 +394,7 @@ stages:
       Your program will be executed like this:
 
       ```bash
-      $ echo "cat" | ./your_grep.sh -E "(cat|dog)"
+      $ echo "cat" | ./your_grep.sh -P "(cat|dog)"
       ```
 
       You program must exit with 0 if the input matches the given pattern, and 1 if not.


### PR DESCRIPTION
the purpose of this change is to keep consistency.
ripgrep requires the '-P' flag to enable support for backreferences.
more details [here](https://github.com/codecrafters-io/grep-tester/pull/9)