### PR TITLE
CC-2203: Upgrade Odin to dev-2026-03

### DIFF
--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -31,7 +31,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-03)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/odin/codecrafters.yml
+++ b/compiled_starters/odin/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.3
+buildpack: odin-2026.3

--- a/compiled_starters/odin/src/main.odin
+++ b/compiled_starters/odin/src/main.odin
@@ -5,7 +5,6 @@ import "core:os"
 import "core:strings"
 import "core:io"
 import "core:unicode/utf8"
-import "core:bytes"
 import "core:bufio"
 
 match_line :: proc(line: string, pattern: string) -> (matched: bool, err: string) {
@@ -31,9 +30,9 @@ main :: proc() {
 
     pattern := os.args[2]
 
-    stdin_stream := os.stream_from_handle(os.stdin)
+    stdin_reader := os.to_reader(os.stdin)
     reader := bufio.Reader{}
-    bufio.reader_init(&reader, stdin_stream)
+    bufio.reader_init(&reader, stdin_reader)
 
     line, read_err := bufio.reader_read_string(&reader, 0)
     if read_err != nil && read_err != io.Error.EOF {

--- a/dockerfiles/odin-2026.3.Dockerfile
+++ b/dockerfiles/odin-2026.3.Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM silkeh/clang:21-trixie
+
+WORKDIR /Odin-install
+RUN git clone --depth 1 -b dev-2026-03 https://github.com/odin-lang/Odin.git /Odin-install \
+    && git checkout dev-2026-03 \
+    && make
+
+RUN mkdir /opt/Odin \
+    && cp -R ./base ./core ./shared ./vendor ./odin /opt/Odin/
+
+WORKDIR /
+RUN rm -rf /Odin-install
+ENV PATH="/opt/Odin:${PATH}"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install language-specific dependencies
+RUN .codecrafters/compile.sh

--- a/solutions/odin/01-cq2/code/README.md
+++ b/solutions/odin/01-cq2/code/README.md
@@ -31,7 +31,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `odin` installed locally
+1. Ensure you have `odin (dev-2026-03)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.odin`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/odin/01-cq2/code/codecrafters.yml
+++ b/solutions/odin/01-cq2/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Odin version used to run your code
 # on Codecrafters.
 #
-# Available versions: odin-2025.7
-buildpack: odin-2025.7
+# Available versions: odin-2026.3
+buildpack: odin-2026.3

--- a/solutions/odin/01-cq2/code/src/main.odin
+++ b/solutions/odin/01-cq2/code/src/main.odin
@@ -5,7 +5,6 @@ import "core:os"
 import "core:strings"
 import "core:io"
 import "core:unicode/utf8"
-import "core:bytes"
 import "core:bufio"
 
 match_line :: proc(line: string, pattern: string) -> (matched: bool, err: string) {
@@ -27,9 +26,9 @@ main :: proc() {
 
     pattern := os.args[2]
 
-    stdin_stream := os.stream_from_handle(os.stdin)
+    stdin_reader := os.to_reader(os.stdin)
     reader := bufio.Reader{}
-    bufio.reader_init(&reader, stdin_stream)
+    bufio.reader_init(&reader, stdin_reader)
 
     line, read_err := bufio.reader_read_string(&reader, 0)
     if read_err != nil && read_err != io.Error.EOF {

--- a/solutions/odin/01-cq2/diff/src/main.odin.diff
+++ b/solutions/odin/01-cq2/diff/src/main.odin.diff
@@ -1,4 +1,4 @@
-@@ -1,47 +1,43 @@
+@@ -1,46 +1,42 @@
  package main
 
  import "core:fmt"
@@ -6,7 +6,6 @@
  import "core:strings"
  import "core:io"
  import "core:unicode/utf8"
- import "core:bytes"
  import "core:bufio"
 
  match_line :: proc(line: string, pattern: string) -> (matched: bool, err: string) {
@@ -33,9 +32,9 @@
 
      pattern := os.args[2]
 
-     stdin_stream := os.stream_from_handle(os.stdin)
+     stdin_reader := os.to_reader(os.stdin)
      reader := bufio.Reader{}
-     bufio.reader_init(&reader, stdin_stream)
+     bufio.reader_init(&reader, stdin_reader)
 
      line, read_err := bufio.reader_read_string(&reader, 0)
      if read_err != nil && read_err != io.Error.EOF {

--- a/starter_templates/odin/code/src/main.odin
+++ b/starter_templates/odin/code/src/main.odin
@@ -5,7 +5,6 @@ import "core:os"
 import "core:strings"
 import "core:io"
 import "core:unicode/utf8"
-import "core:bytes"
 import "core:bufio"
 
 match_line :: proc(line: string, pattern: string) -> (matched: bool, err: string) {
@@ -31,9 +30,9 @@ main :: proc() {
 
     pattern := os.args[2]
 
-    stdin_stream := os.stream_from_handle(os.stdin)
+    stdin_reader := os.to_reader(os.stdin)
     reader := bufio.Reader{}
-    bufio.reader_init(&reader, stdin_stream)
+    bufio.reader_init(&reader, stdin_reader)
 
     line, read_err := bufio.reader_read_string(&reader, 0)
     if read_err != nil && read_err != io.Error.EOF {

--- a/starter_templates/odin/config.yml
+++ b/starter_templates/odin/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: odin
+  required_executable: odin (dev-2026-03)
   user_editable_file: src/main.odin


### PR DESCRIPTION
CC-2203: Upgrade Odin to dev-2026-03

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Odin toolchain/buildpack to a new dev release, which may introduce compiler/runtime behavior changes that affect all Odin submissions. Code changes are small but touch starter templates and Docker build infrastructure.
> 
> **Overview**
> Upgrades the Odin starter/solution environment to `odin-2026.3` (Odin `dev-2026-03`) and updates related docs/config (`codecrafters.yml`, `config.yml`, READMEs) to reflect the new required version.
> 
> Adds a new `dockerfiles/odin-2026.3.Dockerfile` that builds Odin from the `dev-2026-03` branch, and updates Odin starter code to use the newer stdin API (`os.to_reader(os.stdin)` instead of `os.stream_from_handle`) while removing an unused `core:bytes` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198e1e2e57095917bc38fbb075513596bfaa7d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->