### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/Gemfile.lock
+++ b/compiled_starters/ruby/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/solutions/ruby/01-cq2/code/Gemfile.lock
+++ b/solutions/ruby/01-cq2/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/starter_templates/ruby/code/Gemfile.lock
+++ b/starter_templates/ruby/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change updating the recorded Bundler version; may affect local/dev tooling expectations if environments still use Bundler 2.x.
> 
> **Overview**
> Updates Ruby starter/solution `Gemfile.lock` files to record **Bundler 4.0.10** (from 2.5.6) and normalizes the `PLATFORMS` list ordering (re-adding `x86_64-linux` after `ruby`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49164bdfb5fe5d3546ea6a6c4beddd8866cf6dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->