### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -18,12 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -18,12 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/c/01-cq2/code/README.md
+++ b/solutions/c/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/cpp/01-cq2/code/README.md
+++ b/solutions/cpp/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/csharp/01-cq2/code/README.md
+++ b/solutions/csharp/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/gleam/01-cq2/code/README.md
+++ b/solutions/gleam/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/go/01-cq2/code/README.md
+++ b/solutions/go/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/haskell/01-cq2/code/README.md
+++ b/solutions/haskell/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/java/01-cq2/code/README.md
+++ b/solutions/java/01-cq2/code/README.md
@@ -18,12 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/javascript/01-cq2/code/README.md
+++ b/solutions/javascript/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/kotlin/01-cq2/code/README.md
+++ b/solutions/kotlin/01-cq2/code/README.md
@@ -18,12 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/odin/01-cq2/code/README.md
+++ b/solutions/odin/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/php/01-cq2/code/README.md
+++ b/solutions/php/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/python/01-cq2/code/README.md
+++ b/solutions/python/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ruby/01-cq2/code/README.md
+++ b/solutions/ruby/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/rust/01-cq2/code/README.md
+++ b/solutions/rust/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/typescript/01-cq2/code/README.md
+++ b/solutions/typescript/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/zig/01-cq2/code/README.md
+++ b/solutions/zig/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -15,11 +15,10 @@ parsers/lexers work, and how regular expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and
-push your changes to pass the first stage:
+then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates across starter/solution READMEs; no runtime or build logic changes.
> 
> **Overview**
> Updates the *“Passing the first stage”* instructions across all grep starter and reference-solution READMEs (and the shared `starter_templates/all` README) to **replace the `git commit`/`git push` flow with `codecrafters submit`**, clarifying that this runs tests on CodeCrafters’ servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d36252ec5a99eedea4e1ceae1dc0164c5787a2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->