### PR TITLE
Revert "https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit"

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.c`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.go`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/haskell/README.md
+++ b/compiled_starters/haskell/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -18,11 +18,12 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and then run the command below to execute
-the tests on our servers:
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.js`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -18,11 +18,12 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
-run the command below to execute the tests on our servers:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
+your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/odin/README.md
+++ b/compiled_starters/odin/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.php`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.py`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/c/01-cq2/code/README.md
+++ b/solutions/c/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.c`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/cpp/01-cq2/code/README.md
+++ b/solutions/cpp/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/csharp/01-cq2/code/README.md
+++ b/solutions/csharp/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/gleam/01-cq2/code/README.md
+++ b/solutions/gleam/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/go/01-cq2/code/README.md
+++ b/solutions/go/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.go`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/haskell/01-cq2/code/README.md
+++ b/solutions/haskell/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/Main.hs`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/java/01-cq2/code/README.md
+++ b/solutions/java/01-cq2/code/README.md
@@ -18,11 +18,12 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and then run the command below to execute
-the tests on our servers:
+Study and uncomment the relevant code, and push your changes to pass the first
+stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/javascript/01-cq2/code/README.md
+++ b/solutions/javascript/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.js`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/kotlin/01-cq2/code/README.md
+++ b/solutions/kotlin/01-cq2/code/README.md
@@ -18,11 +18,12 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
-run the command below to execute the tests on our servers:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
+your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/odin/01-cq2/code/README.md
+++ b/solutions/odin/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.odin`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/php/01-cq2/code/README.md
+++ b/solutions/php/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.php`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/python/01-cq2/code/README.md
+++ b/solutions/python/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.py`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/ruby/01-cq2/code/README.md
+++ b/solutions/ruby/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/rust/01-cq2/code/README.md
+++ b/solutions/rust/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/typescript/01-cq2/code/README.md
+++ b/solutions/typescript/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/solutions/zig/01-cq2/code/README.md
+++ b/solutions/zig/01-cq2/code/README.md
@@ -18,11 +18,11 @@ expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and then run the command below to execute the tests
-on our servers:
+uncomment the relevant code, and push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -15,10 +15,11 @@ parsers/lexers work, and how regular expressions are evaluated.
 # Passing the first stage
 
 The entry point for your `grep` implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and
-then run the command below to execute the tests on our servers:
+push your changes to pass the first stage:
 
 ```sh
-codecrafters submit
+git commit -am "pass 1st stage" # any msg
+git push origin master
 ```
 
 Time to move on to the next stage!


### PR DESCRIPTION
Reverts codecrafters-io/build-your-own-grep#218

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates README instructions across multiple language starters/solutions and the template; no runtime code or build logic is affected.
> 
> **Overview**
> Reverts the “first stage” instructions across all language `compiled_starters` READMEs, `solutions/*/01-cq2/code/README.md`, and `starter_templates/all/code/README.md` to tell users to `git commit` + `git push` instead of running `codecrafters submit`.
> 
> The stage text is adjusted accordingly ("push your changes to pass the first stage"), while later stages still reference `codecrafters submit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbe0d03b383d80802f77961ef927d4e1b7c7074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->