### PR TITLE
CC-2274: Upgrade Gleam to v0.16

### DIFF
--- a/compiled_starters/gleam/gleam.toml
+++ b/compiled_starters/gleam/gleam.toml
@@ -6,8 +6,8 @@ version = "1.0.0"
 
 [dependencies]
 argv = ">= 1.0.2 and < 2.0.0"
-gleam_erlang = "~> 1.3.0"
-gleam_stdlib = "~> 1.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleescript = ">= 1.4.0 and < 2.0.0"

--- a/compiled_starters/gleam/manifest.toml
+++ b/compiled_starters/gleam/manifest.toml
@@ -16,7 +16,7 @@ packages = [
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
-gleam_erlang = { version = "~> 1.3.0" }
-gleam_stdlib = { version = "~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/compiled_starters/gleam/src/main.gleam
+++ b/compiled_starters/gleam/src/main.gleam
@@ -1,14 +1,13 @@
 import argv
-import gleam/erlang
 import gleam/io
 import gleam/string
 
 pub fn main() {
+  let args = argv.load().arguments
+  let input_line = get_line("")
+
   // You can use print statements as follows for debugging, they'll be visible when running tests.
   io.print_error("Logs from your program will appear here!")
-
-  let args = argv.load().arguments
-  let assert Ok(input_line) = erlang.get_line("")
 
   // TODO: Uncomment the code below to pass the first stage
   // case args {
@@ -34,6 +33,9 @@ fn match_pattern(input_line: String, pattern: String) -> Bool {
     }
   }
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String
 
 @external(erlang, "erlang", "halt")
 pub fn exit(code: Int) -> Int

--- a/solutions/gleam/01-cq2/code/gleam.toml
+++ b/solutions/gleam/01-cq2/code/gleam.toml
@@ -6,8 +6,8 @@ version = "1.0.0"
 
 [dependencies]
 argv = ">= 1.0.2 and < 2.0.0"
-gleam_erlang = "~> 1.3.0"
-gleam_stdlib = "~> 1.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleescript = ">= 1.4.0 and < 2.0.0"

--- a/solutions/gleam/01-cq2/code/manifest.toml
+++ b/solutions/gleam/01-cq2/code/manifest.toml
@@ -16,7 +16,7 @@ packages = [
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
-gleam_erlang = { version = "~> 1.3.0" }
-gleam_stdlib = { version = "~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/01-cq2/code/src/main.gleam
+++ b/solutions/gleam/01-cq2/code/src/main.gleam
@@ -1,11 +1,10 @@
 import argv
-import gleam/erlang
 import gleam/io
 import gleam/string
 
 pub fn main() {
   let args = argv.load().arguments
-  let assert Ok(input_line) = erlang.get_line("")
+  let input_line = get_line("")
 
   case args {
     ["-E", pattern, ..] -> {
@@ -30,6 +29,9 @@ fn match_pattern(input_line: String, pattern: String) -> Bool {
     }
   }
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String
 
 @external(erlang, "erlang", "halt")
 pub fn exit(code: Int) -> Int

--- a/solutions/gleam/01-cq2/diff/src/main.gleam.diff
+++ b/solutions/gleam/01-cq2/diff/src/main.gleam.diff
@@ -1,16 +1,15 @@
-@@ -1,39 +1,35 @@
+@@ -1,41 +1,37 @@
  import argv
- import gleam/erlang
  import gleam/io
  import gleam/string
 
  pub fn main() {
+   let args = argv.load().arguments
+   let input_line = get_line("")
+
 -  // You can use print statements as follows for debugging, they'll be visible when running tests.
 -  io.print_error("Logs from your program will appear here!")
 -
-   let args = argv.load().arguments
-   let assert Ok(input_line) = erlang.get_line("")
-
 -  // TODO: Uncomment the code below to pass the first stage
 -  // case args {
 -  //   ["-E", pattern, ..] -> {
@@ -47,6 +46,9 @@
      }
    }
  }
+
+ @external(erlang, "io", "get_line")
+ fn get_line(prompt prompt: String) -> String
 
  @external(erlang, "erlang", "halt")
  pub fn exit(code: Int) -> Int

--- a/starter_templates/gleam/code/gleam.toml
+++ b/starter_templates/gleam/code/gleam.toml
@@ -6,8 +6,8 @@ version = "1.0.0"
 
 [dependencies]
 argv = ">= 1.0.2 and < 2.0.0"
-gleam_erlang = "~> 1.3.0"
-gleam_stdlib = "~> 1.0"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
+gleam_stdlib = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleescript = ">= 1.4.0 and < 2.0.0"

--- a/starter_templates/gleam/code/manifest.toml
+++ b/starter_templates/gleam/code/manifest.toml
@@ -16,7 +16,7 @@ packages = [
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
-gleam_erlang = { version = "~> 1.3.0" }
-gleam_stdlib = { version = "~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 1.0.0 and < 2.0.0" }
 gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/starter_templates/gleam/code/src/main.gleam
+++ b/starter_templates/gleam/code/src/main.gleam
@@ -1,14 +1,13 @@
 import argv
-import gleam/erlang
 import gleam/io
 import gleam/string
 
 pub fn main() {
+  let args = argv.load().arguments
+  let input_line = get_line("")
+
   // You can use print statements as follows for debugging, they'll be visible when running tests.
   io.print_error("Logs from your program will appear here!")
-
-  let args = argv.load().arguments
-  let assert Ok(input_line) = erlang.get_line("")
 
   // TODO: Uncomment the code below to pass the first stage
   // case args {
@@ -34,6 +33,9 @@ fn match_pattern(input_line: String, pattern: String) -> Bool {
     }
   }
 }
+
+@external(erlang, "io", "get_line")
+fn get_line(prompt prompt: String) -> String
 
 @external(erlang, "erlang", "halt")
 pub fn exit(code: Int) -> Int


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk template/solution maintenance change that updates dependency constraints and adjusts how stdin is read; minimal behavior change limited to input handling in Gleam starter code.
> 
> **Overview**
> Updates the Gleam starter and solution templates to be compatible with newer Gleam by widening `gleam_erlang`/`gleam_stdlib` dependency ranges (and regenerating `manifest.toml` requirements accordingly).
> 
> Refactors `main.gleam` in starters/solutions to stop using `gleam/erlang.get_line` with `Ok` assertions and instead bind an `@external(erlang, "io", "get_line")` `get_line` that returns a `String` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b14a21d922b13e8130f57ba25f7eedc99e5e3e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->